### PR TITLE
use fmt from cms externals; set c++std to 20

### DIFF
--- a/rocm.spec
+++ b/rocm.spec
@@ -1,4 +1,5 @@
 ### RPM external rocm 6.2.4
+## INCLUDE cpp-standard
 
 # AMD repository with RPM packages for RHEL 8 and 9
 %define repository repo.radeon.com/rocm/rhel%{rhel}
@@ -38,10 +39,10 @@ Source19: https://%{repository}/%{repoversion}/main/rocprofiler-plugins-2.0.6020
 Source20: https://%{repository}/%{repoversion}/main/amd-smi-lib-24.6.3.60204-139.el%{rhel}.%{_arch}.rpm
 
 # sources for rocprofiler-register
-Source21: git+https://github.com/ROCm/rocprofiler-register.git?obj=%{rocprofiler_register_branch}/%{rocprofiler_register_tag}&export=%{rocprofiler_register_pkg}&submodules=1&output=/%{rocprofiler_register_name}.tgz
+Source21: git+https://github.com/ROCm/rocprofiler-register.git?obj=%{rocprofiler_register_branch}/%{rocprofiler_register_tag}&export=%{rocprofiler_register_pkg}&submodules=1&output=/%{rocprofiler_register_pkg}.tgz
 
 BuildRequires: gmake cmake
-Requires: numactl zstd
+Requires: numactl zstd fmt
 Requires: python3
 AutoReq: no
 
@@ -75,10 +76,20 @@ rpm2cpio %{SOURCE19} | cpio -idmv
 rpm2cpio %{SOURCE20} | cpio -idmv
 
 # build rocprofiler-register
+sed -i -e 's|add_subdirectory(external)|find_package(fmt REQUIRED)\nadd_subdirectory(external)|' src/%{rocprofiler_register_pkg}/CMakeLists.txt
+%if %{cms_cxx_standard} != 17
+grep -q 'CMAKE_CXX_STANDARD  *17' src/%{rocprofiler_register_pkg}/cmake/rocprofiler_register_options.cmake
+sed -i -e  's|CMAKE_CXX_STANDARD  *17|CMAKE_CXX_STANDARD %{cms_cxx_standard}|' src/%{rocprofiler_register_pkg}/cmake/rocprofiler_register_options.cmake
+%endif
+
 mkdir -p build/rocprofiler-register
 cd build/rocprofiler-register
-cmake ../../src/%{rocprofiler_register_pkg} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{i}
-make all -j %{compiling_processes}
+cmake ../../src/%{rocprofiler_register_pkg} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{i} \
+  -DCMAKE_CXX_STANDARD=%{cms_cxx_standard} \
+  -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+  -DROCPROFILER_REGISTER_BUILD_FMT=OFF \
+  -DCMAKE_PREFIX_PATH="${FMT_ROOT}"
+make all %{makeprocesses}
 
 %install
 rmdir %{i}

--- a/scram-tools.file/tools/rocm/rocm.xml
+++ b/scram-tools.file/tools/rocm/rocm.xml
@@ -1,4 +1,4 @@
-<tool name="rocm" version="@TOOL_VERSION@" revision="2">
+<tool name="rocm" version="@TOOL_VERSION@" revision="3">
   <info url="https://docs.amd.com/"/>
   <lib name="amdhip64"/>
   <lib name="hsa-runtime64"/>
@@ -28,4 +28,5 @@
   <flags SYSTEM_INCLUDE="1"/>
   <runtime name="ROOT_INCLUDE_PATH" value="$INCLUDE" type="path" join="1"/>
   <runtime name="PATH" value="$ROCM_BASE/bin" type="path"/>
+  <use name="fmt"/>
 </tool>


### PR DESCRIPTION
- Build rocprofiler_register  using `fmt` from cms external.
- Force build using c++ standard of cms 
